### PR TITLE
Use Dload as a binary downloader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,13 @@ composer.lock
 .DS_Store
 *.cache
 /runtime
+
+# Binaries
+/rr
+/rr.exe
+/protoc
+/protoc.exe
+/protoc-gen-php-grpc
+/protoc-gen-php-grpc.exe
+/temporal
+/temporal.exe

--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ php artisan vendor:publish --provider='Spiral\RoadRunnerLaravel\ServiceProvider'
 ## Usage
 
 After package installation, you can download and install [RoadRunner][roadrunner] binary
-using [roadrunner-cli][roadrunner-cli]:
+using Composer script:
 
 ```bash
-./vendor/bin/rr get
+composer get:rr
 ```
 
 ### Basic Configuration (.rr.yaml)
@@ -263,9 +263,22 @@ return [
 ];
 ```
 
+Download Temporal binary for development purposes using the following command:
+
+```bash
+composer get:temporal
+```
+
+To start the Temporal server, you can use the following command:
+
+```bash
+./temporal server start-dev --log-level error --color always
+```
+
 #### Useful links
 
-- [PHP SDK docs](https://docs.temporal.io/develop/php/) 
+- [PHP SDK on GitHub](https://github.com/temporalio/sdk-php)
+- [PHP SDK docs](https://docs.temporal.io/develop/php/)
 - [Code samples](https://github.com/temporalio/samples-php)
 - [Taxi service sample](https://github.com/butschster/podlodka-taxi-service)
 
@@ -372,7 +385,5 @@ MIT License (MIT). Please see [`LICENSE`](./LICENSE) for more information.
 [laravel]:https://laravel.com
 
 [laravel_events]:https://laravel.com/docs/events
-
-[roadrunner-cli]:https://github.com/spiral/roadrunner-cli
 
 [roadrunner-binary-releases]:https://github.com/roadrunner-server/roadrunner/releases

--- a/composer.json
+++ b/composer.json
@@ -35,14 +35,14 @@
   ],
   "require": {
     "php": "^8.2",
-    "spiral/roadrunner-cli": "^2.7",
     "spiral/roadrunner-kv": "^4.0",
     "spiral/roadrunner-jobs": "^4.0",
     "spiral/roadrunner-grpc": "^3.5",
     "laravel/octane": "^2.9",
     "spiral/roadrunner-http": "^3.0",
     "spiral/roadrunner-worker": "^3.0",
-    "temporal/sdk": "^2.0"
+    "temporal/sdk": "^2.0",
+    "internal/dload": "^1.1"
   },
   "require-dev": {
     "laravel/framework": "^12.0",
@@ -67,6 +67,9 @@
     "bin/rr-worker"
   ],
   "scripts": {
+    "get:rr": "dload get rr",
+    "get:temporal": "dload get temporal",
+    "get:protoc": "dload get protoc protoc-gen-php-grpc",
     "cs-check": "vendor/bin/php-cs-fixer fix --dry-run",
     "cs-fix": "vendor/bin/php-cs-fixer fix",
     "refactor": "rector process --config=rector.php",


### PR DESCRIPTION
## Description

Use DLoad to download binaries.

Added commands:

 - `get:rr` to download RoadRunner
 - `get:temporal` to download Temporal Dev
 - `get:protoc` to download Protoc binaries


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated setup instructions in the README to use Composer scripts for downloading RoadRunner and Temporal binaries.
  - Added guidance for setting up and running the Temporal server for development.
  - Expanded "Useful links" with additional PHP SDK resources.

- **Chores**
  - Updated .gitignore to exclude additional binaries and executables from version control.
  - Modified Composer dependencies and scripts to streamline binary downloads and remove unused packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->