### PR TITLE
The "withHeader" method expects the type "string|iterable", "int" is passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+### Fixed
+
+- The "withHeader" method of the "\Spiral\RoadRunner\Jobs\Task\WritableHeadersInterface" interface expects the type "string|iterable", "int" is passed
+
 ## v5.12.0
 
 ### Added

--- a/src/Queue/RoadRunnerJob.php
+++ b/src/Queue/RoadRunnerJob.php
@@ -53,7 +53,7 @@ class RoadRunnerJob extends Job implements JobContract
         $attempts = $this->attempts();
 
         $this->task
-            ->withHeader('attempts', $attempts + 1)
+            ->withHeader('attempts', (string) ++$attempts)
             ->fail($e->getMessage());
 
         parent::failed($e);


### PR DESCRIPTION
## Description

The "withHeader" method of the "\Spiral\RoadRunner\Jobs\Task\WritableHeadersInterface" interface expects the type "string|iterable", "int" is passed

Fixes # (issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add version header `## UNRELEASED`, if it does not exists
* Add description under `Added`/`Changed`/`Fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the handling of the "attempts" header to ensure the value is properly incremented and formatted, preventing type errors.
- **Documentation**
  - Updated the changelog to reflect the fix related to the "attempts" header issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->