### PR TITLE
Tasks were stuck in case of an error, the "release" method did not return them to the queue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 ### Fixed
 
+- Tasks were stuck in case of an error, the "release" method did not return them to the queue.
+- The "calculateBackoff" method incorrectly took the index "$job->attempts()"
 - The "withHeader" method of the "\Spiral\RoadRunner\Jobs\Task\WritableHeadersInterface" interface expects the type "string|iterable", "int" is passed
 
 ## v5.12.0

--- a/src/Queue/QueueWorker.php
+++ b/src/Queue/QueueWorker.php
@@ -187,8 +187,7 @@ final class QueueWorker implements WorkerInterface
     protected function maxAttemptsExceededException(RoadRunnerJob $job): MaxAttemptsExceededException
     {
         return new MaxAttemptsExceededException(
-            $job->resolveName(
-            ) . ' has been attempted too many times or run too long. The job may have previously timed out.',
+            $job->resolveName() . ' has been attempted too many times or run too long. The job may have previously timed out.',
         );
     }
 
@@ -267,9 +266,9 @@ final class QueueWorker implements WorkerInterface
             ',',
             \method_exists($job, 'backoff') && !\is_null($job->backoff())
                 ? $job->backoff()
-                : $options->backoff,
+                : (string) $options->backoff,
         );
 
-        return (int) ($backoff[$job->attempts() - 1] ?? last($backoff));
+        return (int) ($backoff[$job->attempts()] ?? last($backoff));
     }
 }

--- a/src/Queue/RoadRunnerJob.php
+++ b/src/Queue/RoadRunnerJob.php
@@ -48,6 +48,18 @@ class RoadRunnerJob extends Job implements JobContract
         $this->task->complete();
     }
 
+    public function release($delay = 0): void
+    {
+        $attempts = $this->attempts();
+
+        $this->task
+            ->withDelay($delay)
+            ->withHeader('attempts', (string) ++$attempts)
+            ->requeue('release');
+
+        parent::release($delay);
+    }
+
     protected function failed($e): void
     {
         $attempts = $this->attempts();


### PR DESCRIPTION
- Tasks were stuck in case of an error, the "release" method did not return them to the queue.
- The "calculateBackoff" method incorrectly took the index "$job->attempts()"

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file
