### PR TITLE
Fix : increment and forever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 - Tasks were stuck in case of an error, the "release" method did not return them to the queue.
 - The "calculateBackoff" method incorrectly took the index "$job->attempts()"
 - The "withHeader" method of the "\Spiral\RoadRunner\Jobs\Task\WritableHeadersInterface" interface expects the type "string|iterable", "int" is passed
+- Fixed the `$ttl` in the `increment` method
+- The `forever` method passed `$seconds` as 0, `Spiral\RoadRunner\KeyValue` summed `timestamp + 0`, and `forever` was not `forever`
 
 [#147]:https://github.com/roadrunner-php/laravel-bridge/issues/147
 

--- a/src/Cache/RoadRunnerStore.php
+++ b/src/Cache/RoadRunnerStore.php
@@ -60,11 +60,12 @@ final class RoadRunnerStore extends TaggableStore implements LockProvider
 
     public function increment($key, $value = 1)
     {
-        $data = $this->get($this->prefix . $key);
+        $data = $this->get($key);
 
         return tap(((int) $data) + $value, function ($newValue) use ($key): void {
             $ttl = $this->storage->getTtl($this->prefix . $key);
-            $this->storage->set($key, $newValue, $ttl->diff(new \DateTimeImmutable()));
+
+            $this->put($key, $newValue, ($ttl ? $ttl->diff(new \DateTimeImmutable()) : null));
         });
     }
 
@@ -75,7 +76,7 @@ final class RoadRunnerStore extends TaggableStore implements LockProvider
 
     public function forever($key, $value)
     {
-        return $this->put($key, $value, 0);
+        return $this->put($key, $value, null);
     }
 
     public function forget($key)


### PR DESCRIPTION
## Description

 - The `forever` method passed `$seconds` as 0, `Spiral\RoadRunner\KeyValue` summed `timestamp + 0`, and `forever` was not `forever`

 - Fixed the `$ttl` in the `increment` method

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TTL handling in cache increment so values update without unintentionally changing or losing their expiration.
  * Corrected “forever” cache entries to truly never expire, preventing unexpected expirations caused by zero-second TTL behavior.
  * Improved consistency of cache operations to ensure predictable read/write behavior and reliable expiration semantics.

* **Documentation**
  * Updated changelog to reflect fixes for increment TTL handling and the corrected behavior of “forever” cache entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->