### PR TITLE
Fix: many

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 - The "withHeader" method of the "\Spiral\RoadRunner\Jobs\Task\WritableHeadersInterface" interface expects the type "string|iterable", "int" is passed
 - Fixed the `$ttl` in the `increment` method
 - The `forever` method passed `$seconds` as 0, `Spiral\RoadRunner\KeyValue` summed `timestamp + 0`, and `forever` was not `forever`
+- When using `prefix`, the `many` method returns values with `prefix`
 
 [#147]:https://github.com/roadrunner-php/laravel-bridge/issues/147
 

--- a/src/Cache/RoadRunnerStore.php
+++ b/src/Cache/RoadRunnerStore.php
@@ -36,7 +36,7 @@ final class RoadRunnerStore extends TaggableStore implements LockProvider
     {
         $prefixedKeys = \array_map(fn($key) => $this->prefix . $key, $keys);
 
-        return $this->storage->getMultiple($prefixedKeys);
+        return array_combine($keys, \iterator_to_array($this->storage->getMultiple($prefixedKeys)));
     }
 
     public function put($key, $value, $seconds)


### PR DESCRIPTION
## Description

When using `prefix`, the `many` method returns values with `prefix`

before

```php
Array
(
    [:laravel:time] => 06:56:38
    [:laravel:date] => 2025-10-01
)

```

after

```php
array (
  'time' => '06:55:17',
  'date' => '2025-10-01',
)
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file
