### PR TITLE
Fix: lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 - Fixed the `$ttl` in the `increment` method
 - The `forever` method passed `$seconds` as 0, `Spiral\RoadRunner\KeyValue` summed `timestamp + 0`, and `forever` was not `forever`
 - When using `prefix`, the `many` method returns values with `prefix`
+- The `Spiral\RoadRunner\KeyValue\Cache` class will set the value regardless of whether it exists or not - it always resolves the lock, you need to check for the existence of the key using the `has` method
 
 [#147]:https://github.com/roadrunner-php/laravel-bridge/issues/147
 

--- a/src/Cache/RoadRunnerLock.php
+++ b/src/Cache/RoadRunnerLock.php
@@ -25,6 +25,10 @@ final class RoadRunnerLock extends Lock
      */
     public function acquire()
     {
+        if ($this->storage->has($this->name)) {
+            return false;
+        }
+
         return $this->storage->set(
             $this->name,
             $this->owner,


### PR DESCRIPTION
## Description

The `Spiral\RoadRunner\KeyValue\Cache` class will set the value regardless of whether it exists or not - it always resolves the lock, you need to check for the existence of the key using the `has` method

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved lock acquisition to prevent overwriting existing locks by failing fast when a lock already exists.
  - Made cache set operations consistently write and always release associated locks, reducing potential deadlocks.
  - Clarified that key existence should be checked before setting values.

- Documentation
  - Updated changelog to reflect revised cache write behavior and lock handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->